### PR TITLE
added enum class for race

### DIFF
--- a/src/main/java/backend/enums/Race.java
+++ b/src/main/java/backend/enums/Race.java
@@ -1,0 +1,43 @@
+package backend.enums;
+
+/**
+ * Character Race
+ * <p>
+ *     One race is set at character creation. <br>
+ *     Race has a impact on Character Abilities,
+ *     with each race offering different bonuses.
+ * </p>
+ *
+ * @author oleablossom
+ */
+public enum Race {
+    /**
+     * No specified race
+     * (no bonus to any stat)
+     */
+    NONE,
+
+    /**
+     * Human
+     * (all-rounder)
+     */
+    HUM,
+
+    /**
+     * Dwarf
+     * (strong, sturdy, wise)
+     */
+    DWA,
+
+    /**
+     * Elf
+     * (agile, intelligent, wise)
+     */
+    ELF,
+
+    /**
+     * Hobbit
+     * (agile, wise, sturdy)
+     */
+    HOB,
+}


### PR DESCRIPTION
I used three-letter codes to represent all races (except none), so that our code lines don't get too long -- but maybe I should use the full names?

I think this will only be used in one class that gets called during character creation